### PR TITLE
Swamy/18sep work

### DIFF
--- a/EnglishLearning/Vocabulary/B.md
+++ b/EnglishLearning/Vocabulary/B.md
@@ -29,6 +29,11 @@ This file contains definitions and example usage for "B" words found in the insp
 **Meaning**: A limit of a subject or sphere of activity; a dividing line.
 **Usage**: "Setting boundaries is essential for self-care." - Knowing where to draw the line in relationships and responsibilities is important for mental health.
 
+## Bragging
+
+**Meaning**: Boastful or arrogant behavior; talking about one's achievements or possessions in a way that shows too much pride.
+**Usage**: "His constant bragging about his success became tiresome." - Excessive pride in one's accomplishments can alienate others.
+
 ## Breathe
 
 **Meaning**: To take air into the lungs and then expel it; to inhale and exhale.

--- a/Scripts/Debug.md
+++ b/Scripts/Debug.md
@@ -137,6 +137,20 @@ pwsh -NoProfile -ExecutionPolicy Bypass -File "Scripts/Verify-Vocabulary.ps1" -S
 pwsh -NoProfile -ExecutionPolicy Bypass -File "Scripts/Verify-Vocabulary.ps1" -OutFile "Logs/verify-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
 ```
 
+## September 18, 2025 - Quick Verification and B.md Fix
+
+- **Initial status**: `B.md` reported OUT OF ORDER
+- **Action**: Moved `Bragging` to appear after `Boundaries` and before `Breathe` to restore alphabetical order
+- **Result**: ✅ ALL 26 FILES VERIFIED OK
+- **Total Words**: 250 vocabulary words across 26 files
+
+**Commands used:**
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File "Scripts/Verify-Vocabulary.ps1" -ShowMismatches
+pwsh -NoProfile -ExecutionPolicy Bypass -File "Scripts/Verify-Vocabulary.ps1" -OutFile "Logs/verify-$(Get-Date -Format 'yyyyMMdd-HHmmss').txt"
+```
+
 ## September 5, 2025 - Verification and Ordering Fixes
 
 ### Initial Verification with Mismatches


### PR DESCRIPTION
This pull request addresses an ordering issue in the vocabulary list for "B" words and updates the verification documentation to reflect the fix. The main change is the insertion of the word "Bragging" in its correct alphabetical position, along with a log of the verification process.

Vocabulary ordering fix:

* Added the entry for "Bragging" (meaning and usage) to `EnglishLearning/Vocabulary/B.md`, placing it after "Boundaries" and before "Breathe" to maintain alphabetical order.

Documentation and verification:

* Updated `Scripts/Debug.md` with a new log entry dated September 18, 2025, describing the issue, the fix, and commands used for verification, confirming that all 26 files are now correctly ordered and verified.